### PR TITLE
Show platform/account names in consolidated views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2773,8 +2773,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -6438,6 +6438,11 @@
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
+    },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
     },
     "randomatic": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "bloomer": "^0.6.3",
     "bulma": "^0.6.2",
     "client-oauth2": "^4.1.0",
+    "ramda": "^0.25.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-hot-loader": "^3.1.3"

--- a/src/components/Accounts.jsx
+++ b/src/components/Accounts.jsx
@@ -15,7 +15,9 @@ class Accounts extends React.Component {
         });
     }
 
-    fetchUsername = (url, accessToken) => {
+    fetchUsername = (platform, accessToken) => {
+        const url = platform.resources.profile;
+
         fetch(url, {
             headers: new Headers({
                 'Authorization': `Bearer ${accessToken}`,
@@ -29,12 +31,13 @@ class Accounts extends React.Component {
         })
         .then(body => {
             const username = body.username;
+            const key = `${username}@${platform.id}`;
             this.setState((prevState) => {
                 return {
                     ...prevState,
                     usernames: {
                         ...prevState.usernames,
-                        [accessToken]: username
+                        [key]: `${username} (${platform.name})`
                     }
                 };
             });
@@ -49,15 +52,14 @@ class Accounts extends React.Component {
 
         this.state.tokens.map(token => {
             const platform = this.props.platforms.filter(p => p.id === token.platform)[0];
-            const url = platform.resources.profile;
-            this.fetchUsername(url, token.accessToken);
+            this.fetchUsername(platform, token.accessToken);
         });
     };
 
     render() {
-        const accessTokens = Object.keys(this.state.usernames);
-        const usernames = accessTokens.map(accessToken => (
-            <li key={accessToken}>{this.state.usernames[accessToken]}</li>
+        const keys = Object.keys(this.state.usernames);
+        const usernames = keys.map(key => (
+            <li key={key}>{this.state.usernames[key]}</li>
         ));
 
         return (


### PR DESCRIPTION
After fetching data from different accounts/platforms, build a consolidated view that will display the account/platform name. Otherwise it's hard to tell where the data comes from.

## Before
![screenshot from 2018-06-04 23-45-14](https://user-images.githubusercontent.com/1181770/40943453-75b01bca-6851-11e8-93dc-feefc19b13d0.png)

## After
![screenshot from 2018-06-04 23-45-57](https://user-images.githubusercontent.com/1181770/40943460-7b442748-6851-11e8-8ebc-1017ae4b1a6e.png)

